### PR TITLE
Fix formatting in package.json by removing unnecessary characters

### DIFF
--- a/mcp-google-calendar/package.json
+++ b/mcp-google-calendar/package.json
@@ -1,4 +1,3 @@
-@"
 {
   "name": "mcp-google-calendar",
   "version": "1.0.0",
@@ -23,4 +22,3 @@
     "dotenv": "^16.3.1"
   }
 }
-"@ | Out-File -FilePath "package.json" -Encoding utf8


### PR DESCRIPTION
Fix failing npm build by removing the unnecessary characters from the package.json file